### PR TITLE
修复Static-MFC编译失败的问题

### DIFF
--- a/DuiVision/DuiVision.2015.vcxproj
+++ b/DuiVision/DuiVision.2015.vcxproj
@@ -247,6 +247,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='DebugMulti|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='ReleaseMulti|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release-StaticMFC|Win32'">NotUsing</PrecompiledHeader>
     </ClCompile>
     <ClCompile Include="source\Area.cpp" />
     <ClCompile Include="source\CheckButton.cpp" />


### PR DESCRIPTION
修复Static-MFC下pugixml.cpp未定义"不使用头文件"造成编译失败的工程问题